### PR TITLE
KAS-4562 add derived file stamping and fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,10 @@
+// RESOURCE_BASE, MU_APPLICATION_FILE_STORAGE_PATH and STORAGE_PATH are currently unused
+// we only replace the physical file on disk and keep the existing uri's and id's
+// stamped files are not moved to a different folder even if a different storage path was set
 const RESOURCE_BASE = 'http://mu.semte.ch/services/document-stamping-service';
 const MU_APPLICATION_FILE_STORAGE_PATH = '';
 const STORAGE_PATH = `/share/${MU_APPLICATION_FILE_STORAGE_PATH}`;
+
 const JSONAPI_JOB_TYPE = 'document-stamping-jobs';
 const RDF_JOB_TYPE = 'http://mu.semte.ch/vocabularies/ext/FileStampingJob';
 

--- a/lib/stamp.js
+++ b/lib/stamp.js
@@ -4,6 +4,7 @@ import { uuid as generateUuid } from 'mu';
 import { STORAGE_PATH } from '../config';
 import { createFile } from '../queries/file';
 
+// UNUSED method, we don't generate new uuid or file, we replace the current phys file
 async function stampMuFile (fileName, sourceFile, stamp) {
   const srcPath = sourceFile.replace(/^share:\/\//, '/share/');
   const fileUuid = generateUuid();
@@ -75,11 +76,12 @@ async function stampFileToBytes(srcPath, text) {
   return pdfBytes;
 }
 
-async function stampFile (srcPath, text, destPath) {
+async function stampFile(srcPath, text, destPath) {
   const pdfBytes = await stampFileToBytes(srcPath, text);
   return await fsp.writeFile(destPath, pdfBytes);
 }
 
+// unused method
 function drawBackground(page, text, textOptions) {
   const textWidth = textOptions.font.widthOfTextAtSize(text, textOptions.size);
   const textHeight = textOptions.font.heightAtSize(textOptions.size);
@@ -95,6 +97,5 @@ function drawBackground(page, text, textOptions) {
 
 export {
   stampFile,
-  stampMuFile,
   stampFileToBytes
 };

--- a/queries/document.js
+++ b/queries/document.js
@@ -1,6 +1,6 @@
 import { query, sparqlEscapeString, update } from 'mu';
 
-async function documentByIdExists (id) {
+async function documentByIdExists(id) {
   const queryString = `
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -13,7 +13,7 @@ async function documentByIdExists (id) {
   return results.boolean;
 }
 
-async function documentsByIdExist (ids) {
+async function documentsByIdExist(ids) {
   const queryString = `
   PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

--- a/queries/file.js
+++ b/queries/file.js
@@ -1,6 +1,8 @@
+import fs from 'fs';
 import { sparqlEscapeString, sparqlEscapeUri, sparqlEscapeInt, sparqlEscapeDateTime, update, uuid as generateUuid } from 'mu';
 import { RESOURCE_BASE } from '../config';
 
+// TODO update modified, filesize, (created stays the same)
 const createFile = async function (file, physicalUri) {
   const uri = RESOURCE_BASE + `/files/${file.id}`;
   const physicalUuid = generateUuid();
@@ -35,6 +37,43 @@ const createFile = async function (file, physicalUri) {
   return file;
 };
 
+const updateFileMetaData = async function (fileUri, filePath) {
+  const filestats = fs.statSync(filePath);
+  const size = filestats.size;
+  // filestats.birthtime stays the same datetime even when replacing
+  const modified = new Date();
+  const updateQuery = `
+  PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+
+  DELETE {
+    ${sparqlEscapeUri(fileUri)} nfo:fileSize ?size .
+    ${sparqlEscapeUri(fileUri)} dct:modified ?modified .
+    ?physFile nfo:fileSize ?physSize ;
+        dct:modified ?physModified .
+  }
+  INSERT {
+      ${sparqlEscapeUri(fileUri)} nfo:fileSize ${sparqlEscapeInt(size)} ;
+            dct:modified ${sparqlEscapeDateTime(modified)} .
+      ?physFile nfo:fileSize ${sparqlEscapeInt(size)} ;
+            dct:modified ${sparqlEscapeDateTime(modified)} .
+  }
+  WHERE {
+    ${sparqlEscapeUri(fileUri)} a nfo:FileDataObject ;
+          nfo:fileSize ?size .
+    OPTIONAL { ${sparqlEscapeUri(fileUri)} dct:modified ?modified . }
+    ?physFile a nfo:FileDataObject ;
+        nie:dataSource ${sparqlEscapeUri(fileUri)} ;
+        nfo:fileSize ?physSize .
+      OPTIONAL { ?physFile dct:modified ?physModified . }
+  }
+  `;
+  await update(updateQuery);
+  return;
+};
+
 export {
-  createFile
+  createFile,
+  updateFileMetaData
 };


### PR DESCRIPTION


https://kanselarij.atlassian.net/browse/KAS-4562?focusedCommentId=18820



Fixed:
derived file stamping
no restamping already stamped docs on approving agenda
change some metadata after we replaced the file on disk.
added comments on unused code ( where we would create a second file and replace that current one with the newly generated file instead) unsure if that is the correct path. the current method works but is different than I expected it to work.
